### PR TITLE
docs: add DialogueAnalyzer analysis

### DIFF
--- a/docs/components/dialogue-analyzer-analysis.md
+++ b/docs/components/dialogue-analyzer-analysis.md
@@ -1,0 +1,199 @@
+# Component Analysis: DialogueAnalyzer
+
+**Component Name:** DialogueAnalyzer
+**Analyst:** ChatGPT
+**Analysis Date:** 2025-08-19
+**Files Analyzed:**
+- `server/analyzer.py`
+- `server/models.py`
+- `server/app.py`
+- `tests/e2e/test_login_flow.py`
+- `design.md` (Section 4.1)
+
+## Component Overview
+
+### Purpose and Responsibility
+- **Primary Function:** Convert user messages into structured intentions for state modification.
+- **Design Specification:** `design.md` Section 4.1 defines a two-channel analyzer (command and natural language) with normalization and validation.
+- **Actual Implementation:** Provides a `MockAnalyzer` for rule-based parsing and `OpenAIAnalyzer` for LLM-driven extraction, but normalization and validation are limited.
+
+### Dependencies
+- **Input Dependencies:** User message text, partial state context.
+- **Output Dependencies:** Downstream components expecting `IntentionSet` objects (`PatchPlanner`, conflict detection).
+- **External Dependencies:** Optional OpenAI-compatible LLM API via `openai` package.
+
+## Implementation Analysis
+
+### Core Functionality
+
+#### Function: `analyze`
+- **File Location:** `server/analyzer.py:33-41`
+- **Design Specification:** Route input through command parser or LLM-based natural language analyzer.
+- **Actual Implementation:** Checks for leading `/` to invoke `_parse_command`, otherwise `_parse_natural_language`.
+- **Compliance Status:** ⚠️ Partial
+- **Notes:** No fallback to LLM when command parsing fails.
+
+#### Function: `_parse_command`
+- **File Location:** `server/analyzer.py:43-96`
+- **Design Specification:** Deterministic parsing for `/add`, `/edit`, `/del`, `/move`, `/set`, `/link`.
+- **Actual Implementation:** Supports `/add`, `/edit`, `/delete` with regex; `/move`, `/set`, and `/link` patterns exist but are not handled.
+- **Compliance Status:** ⚠️ Partial
+- **Notes:** Missing branch logic for `move`, `set`, and `link` commands.
+
+#### Function: `_parse_natural_language`
+- **File Location:** `server/analyzer.py:98-139`
+- **Design Specification:** LLM-based extraction with normalization and path validation.
+- **Actual Implementation:** Keyword heuristics to infer action and story info; limited to add/modify of stories.
+- **Compliance Status:** ⚠️ Partial
+- **Notes:** Delete actions and non-story entities are unsupported; lacks validation.
+
+#### Function: `_extract_story_info`
+- **File Location:** `server/analyzer.py:141-195`
+- **Design Specification:** Normalize fields (priority, dependencies, defaults).
+- **Actual Implementation:** Extracts priority, title, acceptance criteria, dependencies with simple heuristics.
+- **Compliance Status:** ⚠️ Partial
+- **Notes:** No schema validation or path completion.
+
+#### Function: `_parse_params`
+- **File Location:** `server/analyzer.py:197-224`
+- **Design Specification:** Robust parameter parsing with normalization.
+- **Actual Implementation:** Basic `key=value` parsing with limited type handling.
+- **Compliance Status:** ⚠️ Partial
+- **Notes:** Lacks error handling for malformed inputs.
+
+#### Function: `_parse_llm_response`
+- **File Location:** `server/analyzer.py:455-515`
+- **Design Specification:** Strict JSON extraction and schema validation.
+- **Actual Implementation:** Strips text, extracts JSON substring, converts actions, but relies on `IntentionSet` for validation.
+- **Compliance Status:** ⚠️ Partial
+- **Notes:** Does not enforce schema before Pydantic validation; no explicit error propagation.
+
+#### Function: `OpenAIAnalyzer.analyze`
+- **File Location:** `server/analyzer.py:283-344`
+- **Design Specification:** Use few-shot prompting with strict JSON output.
+- **Actual Implementation:** Builds prompt, calls LLM, logs details, falls back to `MockAnalyzer` on errors.
+- **Compliance Status:** ✅ Compliant
+- **Notes:** Relies on external API availability.
+
+### Data Models
+
+#### Model: `Intention`
+- **File Location:** `server/models.py:38-66`
+- **Design Specification:** Fields `action`, `target_path`, `value`, `reason`, `confidence`.
+- **Actual Structure:** Matches design and adds optional `evidence` field and validators for consistency.
+- **Compliance Status:** ⚠️ Partial
+- **Missing Fields:** None
+- **Extra Fields:** `evidence`
+
+#### Model: `IntentionSet`
+- **File Location:** `server/models.py:88-122`
+- **Design Specification:** Collection of `Intention` objects with notes.
+- **Actual Structure:** Matches design; includes validation for conflicts and confidence.
+- **Compliance Status:** ✅ Compliant
+- **Missing Fields:** None
+- **Extra Fields:** None
+
+### Error Handling
+- **Error Types Handled:** JSON parsing errors, data validation errors, missing analyzer configuration.
+- **Error Response Format:** Returns empty `IntentionSet` with notes or raises HTTPException in API layer.
+- **Design Compliance:** ⚠️ Partial
+- **Missing Error Handling:** Path validation errors, unrecognized commands, LLM timeout handling.
+
+### Performance Considerations
+- **Observed Performance:** Command parsing is O(1); LLM calls dominate latency.
+- **Design Targets:** None specified in design for analyzer.
+- **Bottlenecks Identified:** External LLM latency.
+- **Optimization Opportunities:** Caching of frequent prompts, asynchronous command parsing.
+
+## Testing Analysis
+
+### Test Coverage
+- **Test Files:** `tests/e2e/test_login_flow.py`
+- **Coverage Areas:** End-to-end addition of a login story and conflict detection.
+- **Missing Tests:** Command parsing paths, natural language parsing, error scenarios.
+- **Test Quality:** Covers happy path; lacks unit tests and negative cases.
+
+### Integration Testing
+- **Integration Points Tested:** Session creation, intention submission, patch proposal, commit flow.
+- **Missing Integration Tests:** LLM failure scenarios, command-channel interactions.
+
+## Gap Analysis
+
+### Critical Gaps (High Priority)
+1. **Gap:** Missing support for `/move`, `/set`, `/link` commands.
+   - **Impact:** Users cannot perform required state manipulations via command channel.
+   - **Recommended Action:** Implement parsing branches for remaining commands.
+   - **Effort Estimate:** Medium
+
+2. **Gap:** Lack of path validation and schema normalization in natural language parsing.
+   - **Impact:** Invalid intentions may proceed to later stages, risking state corruption.
+   - **Recommended Action:** Integrate validation against current state schema.
+   - **Effort Estimate:** Large
+
+### Non-Critical Gaps (Medium/Low Priority)
+1. **Gap:** Natural language channel lacks delete and non-story entity handling.
+   - **Impact:** Limited functionality for NL users.
+   - **Recommended Action:** Extend heuristics or LLM prompts to cover additional actions.
+   - **Effort Estimate:** Medium
+
+### Enhancement Opportunities
+1. **Opportunity:** Replace heuristic `_parse_natural_language` with full LLM analysis even for non-command messages.
+   - **Benefit:** Consistent intent extraction with fewer edge cases.
+   - **Recommended Action:** Invoke `OpenAIAnalyzer` when available, using `MockAnalyzer` only as fallback.
+   - **Effort Estimate:** Medium
+
+## Code Quality Assessment
+
+### Code Structure
+- **Organization:** Major functions are grouped logically but mix English and Chinese comments.
+- **Naming Conventions:** Follows snake_case and PascalCase per project standards.
+- **Documentation:** Minimal docstrings; comments are informal.
+- **Complexity:** Moderate; command parsing and LLM handling are straightforward.
+
+### Technical Debt
+- **Identified Debt:** Unimplemented command branches, heuristic NL parsing.
+- **Refactoring Needs:** Separate command parsing into dedicated classes for extendability.
+- **Code Smells:** Extensive logging within `_parse_llm_response` may clutter output.
+
+## Security Analysis
+
+### Security Considerations
+- **Input Validation:** Limited; relies on regex and basic parsing without sanitization.
+- **Authentication/Authorization:** Uses API keys for LLM access but no protection against prompt injection.
+- **Data Protection:** No sensitive data handling within analyzer.
+- **Vulnerabilities:** Potential denial-of-service via large messages or malformed commands.
+
+## Configuration and Environment
+
+### Configuration Requirements
+- **Environment Variables:** `OPENAI_API_KEY` or `CSE_API_KEY`, optional `CSE_MODEL`, `OPENAI_BASE_URL`.
+- **Default Values:** Falls back to mock analyzer if keys are missing.
+- **Configuration Validation:** Minimal; missing keys only logged.
+
+### Deployment Considerations
+- **Deployment Requirements:** Network access for LLM, Python runtime.
+- **Resource Requirements:** Dependent on LLM latency; minimal local CPU usage.
+- **Scaling Considerations:** Multiple requests may contend for LLM rate limits.
+
+## Recommendations
+
+### Immediate Actions (0-2 weeks)
+1. Implement parsing logic for `/move`, `/set`, `/link` commands (High, Medium).
+2. Add unit tests for command and natural language parsing (High, Medium).
+
+### Short-term Actions (2-8 weeks)
+1. Integrate schema and path validation into analyzer outputs (High, Large).
+2. Expand natural language parsing to support delete and non-story entities (Medium, Medium).
+
+### Long-term Actions (8+ weeks)
+1. Consolidate analyzer into unified LLM-driven pipeline with fallback (Medium, Large).
+2. Introduce prompt sanitization and rate limiting for security (Medium, Medium).
+
+## Additional Notes
+- Current implementation mixes Chinese and English, which may hinder maintainability.
+
+---
+
+**Analysis Complete:** ✅ Yes
+**Reviewed By:** _N/A_
+**Review Date:** _N/A_


### PR DESCRIPTION
## Summary
- document DialogueAnalyzer component covering command parsing, natural language handling, data models, error handling, and gaps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68a41793fbd48324ab2b4042a77e026b