### PR TITLE
docs: add frontend architecture analysis

### DIFF
--- a/docs/components/frontend-architecture-analysis.md
+++ b/docs/components/frontend-architecture-analysis.md
@@ -1,0 +1,162 @@
+# Component Analysis: Frontend Architecture
+
+**Component Name:** Frontend Architecture
+**Analyst:** ChatGPT
+**Analysis Date:** 2025-08-19
+**Files Analyzed:**
+- `web/src/App.tsx`
+- `web/src/components/CommandInput.tsx`
+- `web/src/components/DiffPanel.tsx`
+- `web/src/components/IntentConfirmation.tsx`
+- `web/src/components/SideEffectAnalysis.tsx`
+- `web/src/hooks/useConfirmationFlow.ts`
+- `web/src/utils/commandParser.ts`
+- `web/package.json`
+- `web/vite.config.ts`
+- `web/tsconfig.json`
+- `design.md` (Sections 1, 4.1, 4.5)
+- `gap.md`
+
+## Component Overview
+
+### Purpose and Responsibility
+- **Primary Function:** Provide a React-based client implementing progressive confirmation, state visualization, and API integration for the CSE.
+- **Design Specification:** The design requires deterministic command parsing and a three-stage confirmation flow before commit【F:design.md†L21-L22】【F:design.md†L116-L119】
+- **Actual Implementation:** Current frontend includes command-aware input, confirmation state machine, patch preview, and commit handling, but several design gaps remain.
+
+### Dependencies
+- **Input Dependencies:** Backend REST API, user inputs.
+- **Output Dependencies:** Backend endpoints for sessions, intentions, patch proposals, commits; UI components for confirmation flow.
+- **External Dependencies:** React, fast-json-patch, Vite build system【F:web/package.json†L1-L37】【F:web/vite.config.ts†L1-L16】
+
+## Implementation Analysis
+
+### Core Functionality
+
+#### Function: `parseUserInput`
+- **File Location:** `web/src/components/CommandInput.tsx:23-31` calls `parseUserInput` to classify commands.
+- **Design Specification:** Deterministic command channel covering CRUD operations.
+- **Actual Implementation:** Uses regex-based parser to distinguish structured commands and show context-sensitive UI【F:web/src/components/CommandInput.tsx†L23-L33】【F:web/src/utils/commandParser.ts†L24-L32】
+- **Compliance Status:** ⚠️ Partial
+- **Notes:** Supports `/add`, `/edit`, `/del`, `/set`, `/move`; backend execution still limited.
+
+#### Function: `useConfirmationFlow`
+- **File Location:** `web/src/hooks/useConfirmationFlow.ts:53-118`
+- **Design Specification:** Three stages (intent → change → side-effect) with forward/back navigation【F:design.md†L116-L119】
+- **Actual Implementation:** Hook manages stages, can proceed/back, tracks selections and auto fixes【F:web/src/hooks/useConfirmationFlow.ts†L53-L118】
+- **Compliance Status:** ✅ Compliant
+- **Notes:** Provides scaffold for progressive confirmation; backend endpoints for intermediate confirmations still missing.
+
+#### Function: `handleCommit`
+- **File Location:** `web/src/App.tsx:722-789`
+- **Design Specification:** Final commit applies selected patches and generates artifacts.
+- **Actual Implementation:** Commits via API when proposal ID exists, otherwise applies patches locally and alerts user【F:web/src/App.tsx†L722-L789】
+- **Compliance Status:** ⚠️ Partial
+- **Notes:** Local commit path does not persist changes; missing rollback/history features.
+
+### Data Models
+- None beyond TypeScript interfaces for API responses (`SessionState`, `ImpactAnalysis`, etc.) in `App.tsx`.
+
+### Error Handling
+- Errors set via `setError` and surfaced in UI; API client throws on non-OK responses.
+
+### Performance Considerations
+- No explicit optimizations; DiffPanel computes patch previews in-memory.
+
+## Testing Analysis
+
+### Test Coverage
+- **Test Files:** None in `web/` (`pnpm test` prints placeholder).
+- **Coverage Areas:** N/A
+- **Missing Tests:** All components lack unit tests; integration with backend untested.
+- **Test Quality:** N/A
+
+### Integration Testing
+- No automated integration tests; manual flow only.
+
+## Gap Analysis
+
+### Critical Gaps (High Priority)
+1. **Incomplete backend confirmation endpoints**
+   - **Impact:** `confirmPatches` and related flows throw errors; progressive confirmation cannot hit server.
+   - **Recommended Action:** Implement and wire backend endpoints; update API client.
+   - **Effort Estimate:** Medium
+2. **No persisted commit history**
+   - **Impact:** Local commit path loses audit trail.
+   - **Recommended Action:** Use backend commit for all flows; expose history UI.
+   - **Effort Estimate:** Medium
+
+### Non-Critical Gaps (Medium/Low Priority)
+1. **Limited command parsing coverage**
+   - **Impact:** Parser recognizes basic CRUD but lacks `/link` and validation feedback.
+   - **Recommended Action:** Extend `commandParser` and surface errors.
+   - **Effort Estimate:** Small
+2. **Missing automated tests**
+   - **Impact:** Regressions undetected.
+   - **Recommended Action:** Add unit tests for hooks, utils, and components.
+   - **Effort Estimate:** Medium
+
+### Enhancement Opportunities
+1. **State slicing and search**
+   - **Benefit:** Improves performance for large states.
+   - **Recommended Action:** Implement context slicing per design and gap.md notes.
+   - **Effort Estimate:** Large
+2. **Role-based access control**
+   - **Benefit:** Aligns with design security requirements.
+   - **Recommended Action:** Integrate permissions in UI.
+   - **Effort Estimate:** Medium
+
+## Code Quality Assessment
+
+### Code Structure
+- **Organization:** Components/hooks/utils separated clearly.
+- **Naming Conventions:** Follows TypeScript conventions; uses descriptive names.
+- **Documentation:** Minimal inline comments; function-level docs in utils.
+- **Complexity:** Moderate; `App.tsx` monolithic.
+
+### Technical Debt
+- **Identified Debt:** `App.tsx` handles API, state, and UI; should be decomposed.
+- **Refactoring Needs:** Extract API client and session management into separate modules.
+- **Code Smells:** Large component with multiple responsibilities.
+
+## Security Analysis
+
+### Security Considerations
+- **Input Validation:** Command parser parses but does not sanitize values.
+- **Authentication/Authorization:** Token-based auth in API client; no role checks.
+- **Data Protection:** No encryption or sensitive data handling in frontend.
+- **Vulnerabilities:** Lack of RBAC as noted in gap.md.
+
+## Configuration and Environment
+
+### Configuration Requirements
+- **Environment Variables:** None; Vite proxy targets backend at `localhost:8000`【F:web/vite.config.ts†L7-L13】
+- **Default Values:** Port 5173 for dev server.
+- **Configuration Validation:** TypeScript strict mode enabled【F:web/tsconfig.json†L1-L25】
+
+### Deployment Considerations
+- **Deployment Requirements:** Build via Vite; Node.js environment.
+- **Resource Requirements:** Browser-based; minimal.
+- **Scaling Considerations:** Client-side; scaling via CDN.
+
+## Recommendations
+
+### Immediate Actions (0-2 weeks)
+1. Implement server-side confirmation endpoints and remove local commit path (High, Medium).
+2. Add unit tests for command parser and confirmation flow (Medium, Medium).
+
+### Short-term Actions (2-8 weeks)
+1. Integrate state slicing/search to improve performance (Medium, Large).
+1. Refactor `App.tsx` into smaller components (Low, Medium).
+
+### Long-term Actions (8+ weeks)
+1. Implement RBAC and permission-aware UI elements (High, Large).
+2. Expand command parser to cover `/link` and provide syntax hints (Low, Small).
+
+## Additional Notes
+- gap.md previously reported missing DiffPanel and progressive confirmation; current code integrates both, indicating gap documentation is outdated【F:gap.md†L5-L18】【F:gap.md†L47-L51】
+
+---
+**Analysis Complete:** ✅ Yes  
+**Reviewed By:** N/A  
+**Review Date:** N/A


### PR DESCRIPTION
## Summary
- add frontend architecture analysis documenting command parsing, progressive confirmation flow, commit workflow, and configuration details

## Testing
- `pnpm --filter conversational-state-engine-frontend lint` (fails: @typescript-eslint no-explicit-any errors)
- `pnpm --filter conversational-state-engine-frontend test`
- `uv run pytest -q tests/e2e` (fails: Connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68a4297554408324b6c6bdf231abd628