### PR TITLE
fix: resolve pnpm version conflict in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Install Node dependencies
         run: pnpm install
@@ -151,8 +149,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- remove explicit pnpm version from CI workflow to use package.json packageManager

## Testing
- `uv run pre-commit run --files .github/workflows/ci.yml`
- `uv run pytest -q` *(fails: assert 500 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a46230b29c83248a5365756358f111