### PR TITLE
fix: resolve frontend type issues

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,7 +4,7 @@ import IntentConfirmation from './components/IntentConfirmation';
 import SideEffectAnalysis from './components/SideEffectAnalysis';
 import CommandInput from './components/CommandInput';
 import { Operation } from 'fast-json-patch';
-import { useConfirmationFlow } from './hooks/useConfirmationFlow';
+import { useConfirmationFlow, type IntentSummary } from './hooks/useConfirmationFlow';
 import { parseUserInput } from './utils/commandParser';
 import { inferIntentFromText, validateInferredIntent, suggestCommand } from './utils/intentInference';
 import { generatePatchesFromIntent, validateGeneratedPatches } from './utils/patchGenerator';
@@ -24,6 +24,8 @@ interface Conflict {
   severity: 'low' | 'medium' | 'high';
   message: string;
   suggestion?: Suggestion;
+  affected_paths: string[];
+  examples?: string[];
 }
 
 interface ImpactAnalysis {
@@ -31,6 +33,18 @@ interface ImpactAnalysis {
   risk_level: 'low' | 'medium' | 'high';
   semantic_conflicts: Conflict[];
   suggested_alternatives?: unknown[];
+  risk_explanation?: string;
+  dependency_analysis?: {
+    breaking_changes: string[];
+    cascading_effects: string[];
+    validation_warnings: string[];
+  };
+}
+
+interface Artifact {
+  type?: string;
+  url?: string;
+  [key: string]: unknown;
 }
 
 interface SessionState {
@@ -61,7 +75,7 @@ interface API {
 
   commitState(sessionId: string): Promise<{
     success: boolean;
-    artifacts: unknown[];
+    artifacts: Artifact[];
   }>;
 }
 
@@ -233,7 +247,7 @@ class APIClient implements API {
 
   async commitState(sessionId: string, proposalId?: string): Promise<{
     success: boolean;
-    artifacts: unknown[];
+    artifacts: Artifact[];
   }> {
     if (!proposalId) {
       throw new Error('Proposal ID required for commit');
@@ -247,10 +261,10 @@ class APIClient implements API {
     if (!response.ok) throw new Error('Failed to commit state');
     const result = await response.json();
 
-    return {
-      success: true,
-      artifacts: result.artifacts?.items || []
-    };
+      return {
+        success: true,
+        artifacts: (result.artifacts?.items || []) as Artifact[],
+      };
   }
 }
 
@@ -284,7 +298,7 @@ const App: React.FC = () => {
   const confirmation = useConfirmationFlow();
 
   // Artifacts state
-  const [artifacts, setArtifacts] = useState<unknown[]>([]);
+  const [artifacts, setArtifacts] = useState<Artifact[]>([]);
 
   // Debug logging for state changes
   useEffect(() => {
@@ -388,8 +402,8 @@ const App: React.FC = () => {
   const handleLogout = () => {
     setIsLoggedIn(false);
     setShowAuth(true);
-    setSession(null);
-    setCurrentState(null);
+      setSession(null);
+      setCurrentState({});
     setProposedPatches([]);
     setImpact(null);
     setMessage('');
@@ -414,7 +428,7 @@ const App: React.FC = () => {
       // Parse user input to determine if it's a command or natural language
       const parseResult = parseUserInput(messageInput);
 
-      let intent: Record<string, unknown>;
+        let intent: IntentSummary;
       let patches: Operation[] = [];
       let impact: ImpactAnalysis = { affected_paths: [], risk_level: 'low', semantic_conflicts: [] };
 
@@ -541,16 +555,17 @@ const App: React.FC = () => {
 
         // Add validation warnings to impact if confidence is low
         if (!validation.valid || inferredIntent.confidence < 0.7) {
-          const validationConflicts = validation.issues.map(issue => ({
-            type: 'intent_inference',
-            rule: 'low_confidence_inference',
-            severity: 'medium' as const,
-            message: issue,
-            suggestion: {
-              description: `建议使用命令: ${suggestCommand(inferredIntent, messageInput)}`,
-              auto_fix: false
-            }
-          }));
+            const validationConflicts = validation.issues.map(issue => ({
+              type: 'intent_inference',
+              rule: 'low_confidence_inference',
+              severity: 'medium' as const,
+              message: issue,
+              affected_paths: impact.affected_paths || [],
+              suggestion: {
+                description: `建议使用命令: ${suggestCommand(inferredIntent, messageInput)}`,
+                auto_fix: false
+              }
+            }));
 
           impact = {
             ...impact,
@@ -583,11 +598,11 @@ const App: React.FC = () => {
           examples: conflict.rule === 'auth_method_conflict'
             ? ['SSO与本地密码认证同时启用', '用户可能无法正确登录']
             : ['数据验证失败', '业务逻辑冲突'],
-          suggestion: conflict.rule === 'auth_method_conflict' ? {
-            description: '建议禁用本地密码认证，统一使用SSO',
-            auto_fix: true,
-            patches: [{ op: 'replace', path: '/auth_settings/local_auth', value: false }]
-          } : undefined
+            suggestion: conflict.rule === 'auth_method_conflict' ? {
+              description: '建议禁用本地密码认证，统一使用SSO',
+              auto_fix: true,
+              patches: [{ op: 'replace', path: '/auth_settings/local_auth', value: false } as Operation]
+            } : undefined
         })) || []
       };
 
@@ -996,7 +1011,7 @@ const App: React.FC = () => {
                 onConfirm={handleIntentConfirmed}
                 onCancel={handleConfirmationCancel}
                 loading={loading}
-                preliminaryImpact={impact}
+                  preliminaryImpact={impact ?? undefined}
               />
             ) : confirmation.state.stage === 'change' && confirmation.state.changes && currentState ? (
               <DiffPanel

--- a/web/src/components/DiffPanel.tsx
+++ b/web/src/components/DiffPanel.tsx
@@ -279,11 +279,11 @@ export const DiffPanel: React.FC<DiffPanelProps> = ({
                         </span>
                       </div>
                       <p className="mt-1 text-sm text-gray-700">{conflict.message}</p>
-                      {conflict.suggestion && (
-                        <div className="mt-2 text-xs text-gray-600">
-                          建议: {JSON.stringify(conflict.suggestion)}
-                        </div>
-                      )}
+                        {conflict.suggestion ? (
+                          <div className="mt-2 text-xs text-gray-600">
+                            建议: {JSON.stringify(conflict.suggestion)}
+                          </div>
+                        ) : null}
                     </div>
                   ))}
                 </div>

--- a/web/src/components/EnhancedImpactAnalysis.tsx
+++ b/web/src/components/EnhancedImpactAnalysis.tsx
@@ -14,7 +14,7 @@ interface EnhancedConflict {
   examples?: string[];
 }
 
-interface EnhancedImpactAnalysisData {
+export interface EnhancedImpactAnalysisData {
   affected_paths: string[];
   risk_level: 'low' | 'medium' | 'high';
   semantic_conflicts: EnhancedConflict[];

--- a/web/src/components/IntentConfirmation.tsx
+++ b/web/src/components/IntentConfirmation.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { IntentSummary } from '../hooks/useConfirmationFlow';
-import EnhancedImpactAnalysis from './EnhancedImpactAnalysis';
+import EnhancedImpactAnalysis, { type EnhancedImpactAnalysisData } from './EnhancedImpactAnalysis';
 
 interface IntentConfirmationProps {
   intent: IntentSummary;
   onConfirm: () => void;
   onCancel: () => void;
   loading?: boolean;
-  preliminaryImpact?: unknown; // 初步影响分析
+  preliminaryImpact?: EnhancedImpactAnalysisData; // 初步影响分析
 }
 
 export const IntentConfirmation: React.FC<IntentConfirmationProps> = ({
@@ -100,23 +100,23 @@ export const IntentConfirmation: React.FC<IntentConfirmationProps> = ({
       </div>
 
       {/* 提示信息 */}
-      {intent.confidence < 0.8 && (
-        <div className="mb-6 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-          <div className="flex items-start">
-            <div className="text-yellow-600 text-sm">
-              ⚠️ 置信度较低，建议仔细核对意图理解是否正确。
+        {intent.confidence < 0.8 ? (
+          <div className="mb-6 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
+            <div className="flex items-start">
+              <div className="text-yellow-600 text-sm">
+                ⚠️ 置信度较低，建议仔细核对意图理解是否正确。
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        ) : null}
 
       {/* 初步影响分析 */}
-      {preliminaryImpact && (
-        <div className="mb-6">
-          <h3 className="text-lg font-medium text-gray-900 mb-3">初步影响分析</h3>
-          <EnhancedImpactAnalysis impact={preliminaryImpact} />
-        </div>
-      )}
+        {preliminaryImpact ? (
+          <div className="mb-6">
+            <h3 className="text-lg font-medium text-gray-900 mb-3">初步影响分析</h3>
+            <EnhancedImpactAnalysis impact={preliminaryImpact} />
+          </div>
+        ) : null}
 
       {/* 操作按钮 */}
       <div className="flex justify-between items-center pt-4 border-t border-gray-200">

--- a/web/src/utils/commandParser.ts
+++ b/web/src/utils/commandParser.ts
@@ -114,9 +114,9 @@ function parseCommand(input: string): ParsedCommand | null {
       const params = match[2] || '';
 
       // 解析参数
-      const properties = parseKeyValuePairs(params);
-      const reason = properties.reason;
-      delete properties.reason; // reason不是属性
+        const properties = parseKeyValuePairs(params);
+        const reason = typeof properties.reason === 'string' ? properties.reason : undefined;
+        delete (properties as Record<string, unknown>).reason; // reason不是属性
 
       // 生成目标路径
       const targetPath = generateTargetPath(action, target, properties);

--- a/web/src/utils/intentInference.ts
+++ b/web/src/utils/intentInference.ts
@@ -128,12 +128,12 @@ export function inferIntentFromText(text: string): InferredIntent {
   // 综合置信度
   const overallConfidence = (actionResult.confidence + targetResult.confidence) / 2;
 
-  return {
-    action: actionResult.action as 'add' | 'edit' | 'delete' | 'set' | 'move',
-    target_path: targetResult.path,
-    confidence: overallConfidence,
-    reasoning: `${actionResult.reasoning}; 推断目标: ${targetResult.path}`
-  };
+    return {
+      action: actionResult.action as 'add' | 'modify' | 'delete' | 'set' | 'move',
+      target_path: targetResult.path,
+      confidence: overallConfidence,
+      reasoning: `${actionResult.reasoning}; 推断目标: ${targetResult.path}`
+    };
 }
 
 /**

--- a/web/src/utils/patchTester.ts
+++ b/web/src/utils/patchTester.ts
@@ -95,7 +95,7 @@ export function validatePatchPath(state: unknown, path: string): {
   try {
     const fullPath = path.startsWith('/data') ? path : `/data${path}`;
     const pathParts = fullPath.split('/').filter(part => part !== '');
-    let current = state;
+      let current: unknown = state;
 
     for (let i = 0; i < pathParts.length; i++) {
       const part = pathParts[i];
@@ -128,7 +128,7 @@ export function validatePatchPath(state: unknown, path: string): {
             suggestion: `使用有效的索引 (0-${current.length-1}) 或使用 '-' 添加到末尾`
           };
         }
-        current = current[index];
+          current = current[index];
       } else {
         // 对象属性
         if (current === null || typeof current !== 'object') {
@@ -148,7 +148,7 @@ export function validatePatchPath(state: unknown, path: string): {
           };
         }
 
-        current = current[part];
+          current = (current as Record<string, unknown>)[part];
       }
     }
 


### PR DESCRIPTION
## Summary
- expand impact analysis and artifact typings for React frontend
- handle null state and intent typing during logout and submission
- clean up suggestion rendering and command parsing types

## Testing
- `npm run lint`
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68a46a63bb1483249f26240998eecae1